### PR TITLE
Add configurable minimum operational humidity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ binary_sensor:
   target_offset: 3 # Optional dehumidification target offset. Default = 3
   max_on_time: 7200 # Optional safety max on time in seconds. Default = 7200 seconds
   sample_interval: 300 # Optional time between taking humidity samples in seconds, default 300 seconds
+  min_oper_humidity: 30 # Optional minimum humidity to enable dehumidification. Default = 0
 ```
 It will create a binary sensor called `binary_sensor.bathroom_hygrostat`.
 Next, add some automations to switch your fan:

--- a/custom_components/generic_hygrostat/binary_sensor.py
+++ b/custom_components/generic_hygrostat/binary_sensor.py
@@ -170,7 +170,7 @@ class GenericHygrostat(Entity):
     def set_dehumidification_target(self):
         """Setting dehumidification target to min humidity sample + offset."""
         if self.target is None:
-            self.target = min(self.min_oper_humidity, min(self.samples) + self.target_offset)
+            self.target = min(self.samples) + self.target_offset if self.min_oper_humidity < min(self.samples) else self.min_oper_humidity
 
     def reset_dehumidification_target(self):
         """Unsetting dehumidification target."""

--- a/custom_components/generic_hygrostat/binary_sensor.py
+++ b/custom_components/generic_hygrostat/binary_sensor.py
@@ -30,17 +30,21 @@ ATTR_NUMBER_OF_SAMPLES = 'number_of_samples'
 ATTR_MIN_HUMIDITY = 'min_humidity'
 ATTR_TARGET = 'target'
 ATTR_MAX_ON_TIMER = 'max_on_timer'
+ATTR_MIN_OPER_HUMIDITY = 'min_oper_humidity'
 
 CONF_SENSOR = 'sensor'
 CONF_DELTA_TRIGGER = 'delta_trigger'
 CONF_TARGET_OFFSET = 'target_offset'
 CONF_MAX_ON_TIME = 'max_on_time'
+CONF_MIN_OPER_HUMIDITY = 'min_oper_humidity'
+
 CONF_SAMPLE_INTERVAL = 'sample_interval'
 
 DEFAULT_DELTA_TRIGGER = 3
 DEFAULT_TARGET_OFFSET = 3
 DEFAULT_MAX_ON_TIME = timedelta(seconds=7200)
 DEFAULT_SAMPLE_INTERVAL = timedelta(minutes=5)
+DEFAULT_MIN_OPER_HUMIDITY = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,
@@ -52,7 +56,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MAX_ON_TIME, default=DEFAULT_MAX_ON_TIME):
         cv.time_period,
     vol.Optional(CONF_SAMPLE_INTERVAL, default=DEFAULT_SAMPLE_INTERVAL):
-        cv.time_period
+        cv.time_period,
+    vol.Optional(CONF_MIN_OPER_HUMIDITY, default=DEFAULT_MIN_OPER_HUMIDITY):
+        vol.Coerce(float)
 })
 
 
@@ -65,16 +71,17 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     target_offset = config.get(CONF_TARGET_OFFSET)
     max_on_time = config.get(CONF_MAX_ON_TIME)
     sample_interval = config.get(CONF_SAMPLE_INTERVAL)
+    min_oper_humidity = config.get(CONF_MIN_OPER_HUMIDITY)
 
     async_add_devices([GenericHygrostat(
-        hass, name, sensor_id, delta_trigger, target_offset, max_on_time, sample_interval)])
+        hass, name, sensor_id, delta_trigger, target_offset, max_on_time, sample_interval, min_oper_humidity)])
 
 
 class GenericHygrostat(Entity):
     """Representation of a Generic Hygrostat device."""
 
     def __init__(self, hass, name, sensor_id, delta_trigger, target_offset,
-                 max_on_time, sample_interval):
+                 max_on_time, sample_interval, min_oper_humidity):
         """Initialize the hygrostat."""
         self.hass = hass
         self._name = name
@@ -82,12 +89,14 @@ class GenericHygrostat(Entity):
         self.delta_trigger = delta_trigger
         self.target_offset = target_offset
         self.max_on_time = max_on_time
+        self.min_oper_humidity = min_oper_humidity
 
         self.sensor_humidity = None
         self.target = None
         sample_size = int(SAMPLE_DURATION / sample_interval)
         self.samples = collections.deque([], sample_size)
         self.max_on_timer = None
+        
 
         self._state = STATE_OFF
         self._icon = 'mdi:water-percent'
@@ -107,7 +116,11 @@ class GenericHygrostat(Entity):
         if self.calc_delta() >= self.delta_trigger:
             _LOGGER.debug("Humidity rise detected at '%s' with delta '%s'",
                           self.name, self.calc_delta())
-            self.set_on()
+            if (self.sensor_humidity >= self.min_oper_humidity):
+                self.set_on()
+            else:
+                _LOGGER.debug("Humidity '%s' is below minimum operating humidity '%s'",
+                          self.sensor_humidity, self.min_oper_humidity)
 
         if self.target and self.sensor_humidity <= self.target:
             _LOGGER.debug("Dehumidifying target reached for '%s'",
@@ -157,7 +170,7 @@ class GenericHygrostat(Entity):
     def set_dehumidification_target(self):
         """Setting dehumidification target to min humidity sample + offset."""
         if self.target is None:
-            self.target = min(self.samples) + self.target_offset
+            self.target = min(self.min_oper_humidity, min(self.samples) + self.target_offset)
 
     def reset_dehumidification_target(self):
         """Unsetting dehumidification target."""
@@ -212,5 +225,6 @@ class GenericHygrostat(Entity):
             ATTR_NUMBER_OF_SAMPLES: len(self.samples),
             ATTR_MIN_HUMIDITY: self.get_minimum(),
             ATTR_TARGET: self.target,
-            ATTR_MAX_ON_TIMER: self.max_on_timer
+            ATTR_MAX_ON_TIMER: self.max_on_timer,
+            ATTR_MIN_OPER_HUMIDITY: self.min_oper_humidity
         }

--- a/info.md
+++ b/info.md
@@ -19,6 +19,7 @@ binary_sensor:
   target_offset: 3 # Optional dehumidification target offset. Default = 3
   max_on_time: 7200 # Optional safety max on time in seconds. Default = 7200 seconds
   sample_interval: 300 # Optional time between taking humidity samples in seconds, default 300 seconds
+  min_oper_humidity: 30 # Optional minimum humidity to enable dehumidification. Default = 0
 ```
 It will create a binary sensor called `binary_sensor.bathroom_hygrostat`. 
 Next, add some automations to switch your fan:


### PR DESCRIPTION
It is pretty dry in the winters here in the north and together with hourly electricity meter I want to avoid running the dehumidifier below a certain humidity. I created the option to set the minimum operation humidity, defaults to 0 so it is the same behavior as originally.

If the minimum operational humidity is set to e.g. 30% the humidifier will not trigger below this and when the humidity is close to this value it will only operate until the minimum value is reached.