### PR TITLE
Include version in manifest.json

### DIFF
--- a/custom_components/generic_hygrostat/manifest.json
+++ b/custom_components/generic_hygrostat/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/basschipper/homeassistant-generic-hygrostat",
   "dependencies": [],
   "codeowners": ["@basschipper"],
-  "requirements": []
+  "requirements": [],
+  "version": "0.3.0"
 }


### PR DESCRIPTION
Upcoming changes require version number in the integration manifest

https://developers.home-assistant.io/docs/creating_integration_manifest/