### PR TITLE
Make the history configurable (more than default 15 minutes)

### DIFF
--- a/custom_components/generic_hygrostat/binary_sensor.py
+++ b/custom_components/generic_hygrostat/binary_sensor.py
@@ -22,7 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["sensor"]
 
-SAMPLE_DURATION = timedelta(minutes=15)
 
 DEFAULT_NAME = "Generic Hygrostat"
 
@@ -40,6 +39,7 @@ CONF_TARGET_OFFSET = "target_offset"
 CONF_MIN_ON_TIME = "min_on_time"
 CONF_MAX_ON_TIME = "max_on_time"
 CONF_MIN_HUMIDITY = "min_humidity"
+CONF_SAMPLE_DURATION = "sample_duration"
 
 CONF_SAMPLE_INTERVAL = "sample_interval"
 
@@ -48,6 +48,7 @@ DEFAULT_TARGET_OFFSET = 3
 DEFAULT_MIN_ON_TIME = timedelta(seconds=0)
 DEFAULT_MAX_ON_TIME = timedelta(seconds=7200)
 DEFAULT_SAMPLE_INTERVAL = timedelta(minutes=5)
+DEFAULT_SAMPLE_DURATION = timedelta(minutes=15)
 DEFAULT_MIN_HUMIDITY = 0
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -60,6 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_MIN_ON_TIME, default=DEFAULT_MIN_ON_TIME): cv.time_period,
         vol.Optional(CONF_MAX_ON_TIME, default=DEFAULT_MAX_ON_TIME): cv.time_period,
         vol.Optional(CONF_SAMPLE_INTERVAL, default=DEFAULT_SAMPLE_INTERVAL): cv.time_period,
+        vol.Optional(CONF_SAMPLE_DURATION, default=DEFAULT_SAMPLE_DURATION): cv.time_period,
         vol.Optional(CONF_MIN_HUMIDITY, default=DEFAULT_MIN_HUMIDITY): vol.Coerce(float),
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
@@ -77,6 +79,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     min_on_time = config.get(CONF_MIN_ON_TIME)
     max_on_time = config.get(CONF_MAX_ON_TIME)
     sample_interval = config.get(CONF_SAMPLE_INTERVAL)
+    sample_duration = config.get(CONF_SAMPLE_INTERVAL)
     min_humidity = config.get(CONF_MIN_HUMIDITY)
     unique_id = config.get(CONF_UNIQUE_ID)
 
@@ -92,6 +95,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
                 min_on_time,
                 max_on_time,
                 sample_interval,
+		sample_duration,
                 min_humidity,
                 unique_id,
             )
@@ -113,6 +117,7 @@ class GenericHygrostat(Entity):
         min_on_time,
         max_on_time,
         sample_interval,
+	sample_duration,
         min_humidity,
         unique_id,
     ):
@@ -130,7 +135,7 @@ class GenericHygrostat(Entity):
 
         self.sensor_humidity = None
         self.target = None
-        sample_size = int(SAMPLE_DURATION / sample_interval)
+        sample_size = int(sample_duration / sample_interval)
         self.samples = collections.deque([], sample_size)
         self.min_on_timer = None
         self.max_on_timer = None

--- a/custom_components/generic_hygrostat/binary_sensor.py
+++ b/custom_components/generic_hygrostat/binary_sensor.py
@@ -40,7 +40,6 @@ CONF_MIN_ON_TIME = "min_on_time"
 CONF_MAX_ON_TIME = "max_on_time"
 CONF_MIN_HUMIDITY = "min_humidity"
 CONF_SAMPLE_DURATION = "sample_duration"
-
 CONF_SAMPLE_INTERVAL = "sample_interval"
 
 DEFAULT_DELTA_TRIGGER = 3
@@ -79,7 +78,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     min_on_time = config.get(CONF_MIN_ON_TIME)
     max_on_time = config.get(CONF_MAX_ON_TIME)
     sample_interval = config.get(CONF_SAMPLE_INTERVAL)
-    sample_duration = config.get(CONF_SAMPLE_INTERVAL)
+    sample_duration = config.get(CONF_SAMPLE_DURATION)
     min_humidity = config.get(CONF_MIN_HUMIDITY)
     unique_id = config.get(CONF_UNIQUE_ID)
 

--- a/info.md
+++ b/info.md
@@ -23,6 +23,7 @@ binary_sensor:
   min_on_time: 300 # Optional min on time in seconds. Default = 0 seconds
   max_on_time: 7200 # Optional safety max on time in seconds. Default = 7200 seconds
   sample_interval: 300 # Optional time between taking humidity samples in seconds, default 300 seconds
+  sample_duration: 900 # Memory (for how long time would lowest minimum humidity be tracked back)
   min_humidity: 30 # Optional minimum humidity to enable dehumidification. Default = 0
   unique_id: bathroom_hygrostat # Optional ID that uniquely identifies this sensor. Set this to a unique value to allow customization through the UI.
 ```


### PR DESCRIPTION
I'm not 100% sure - but it looks like the "memory" is 15 minutes for tracking target humidity - which is a bit on the low side in my envioronment. This patch makes SAMPLE_DURATION configurable - in order to lengthen the window. It is tested in my environment. 